### PR TITLE
fix moving file function

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'com.google.android.material:material:1.3.0'
     implementation 'androidx.activity:activity-ktx:1.2.1'
-    implementation 'androidx.fragment:fragment-ktx:1.3.1'
+    implementation 'androidx.fragment:fragment-ktx:1.3.2'
 
     // Firebaes
     implementation platform('com.google.firebase:firebase-bom:26.2.0')

--- a/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt
+++ b/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt
@@ -202,10 +202,10 @@ class CifsRepository @Inject constructor(
      */
     suspend fun renameFile(sourceUri: String, newName: String): CifsFile? {
         return withContext(Dispatchers.IO) {
-            val targetUri = if (sourceUri.isDirectoryUri) {
-                sourceUri.trimEnd('/').replaceAfterLast('/', newName) + '/'
+            val targetUri = if (newName.contains('/', false)) {
+                newName.trimEnd('/') + '/' + Uri.parse(sourceUri).lastPathSegment
             } else {
-                sourceUri.replaceAfterLast('/', newName)
+                sourceUri.trimEnd('/').replaceAfterLast('/', newName)
             }
             try {
                 val source = getSmbFile(sourceUri) ?: return@withContext null
@@ -250,7 +250,7 @@ class CifsRepository @Inject constructor(
                 val targetConnection = getConnection(targetUri) ?: return@withContext null
                 if (sourceConnection == targetConnection) {
                     // Same connection
-                    Uri.parse(targetUri).lastPathSegment?.let { renameFile(sourceUri, it) }
+                    renameFile(sourceUri, targetUri)
                 } else {
                     // Different connection
                     copyFile(sourceUri, targetUri)?.also {


### PR DESCRIPTION
#1 
[L253](https://github.com/wa2c/cifs-documents-provider/blob/132146de088909cb0377c6b79853b4a63481f250/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt#L253). Pass the full smb-uri as a parameter when moving files, no longer check and splite.
[L205](https://github.com/wa2c/cifs-documents-provider/blob/132146de088909cb0377c6b79853b4a63481f250/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt#L205). Handle the case where the new name is actually a uri, which means it should not be a filename.
[L208](https://github.com/wa2c/cifs-documents-provider/blob/132146de088909cb0377c6b79853b4a63481f250/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt#L208). No longer judge whether the path ends with '/', the renaming logic is the same.

Has been compiled and run verification.