### PR TITLE
Fix anonymous auth

### DIFF
--- a/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/CifsClient.kt
+++ b/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/CifsClient.kt
@@ -31,7 +31,7 @@ class CifsClient @Inject constructor() {
         }
 
         return  CIFSContextWrapper(BaseContext(PropertyConfiguration(property))
-            .withCredentials(NtlmPasswordAuthenticator(domain, user, password)))
+            .withCredentials(NtlmPasswordAuthenticator(domain, user, password, null)))
     }
 
     /**


### PR DESCRIPTION
Use 4 parameters ntlmPasswordAuthenticator so jcifs-ng is used for choosing AuthenticationType as intended. See this [issue](https://github.com/AgNO3/jcifs-ng/issues/105) for the discussion. Thanks @mbechler for the hint.