### PR TITLE
Fix an oversight in BackgroundBufferReader.kt

### DIFF
--- a/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/io/BackgroundBufferReader.kt
+++ b/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/io/BackgroundBufferReader.kt
@@ -157,6 +157,7 @@ class BackgroundBufferReader (
                 // Position reset (not contains)
                 logD("[READ] Reset: streamPosition=$streamPosition, bufferRemainSize=$bufferRemainSize, bufferOffset=$bufferOffset")
                 resetCycle(streamPosition)
+                continue
             }
             val readRemainSize = maxSize - readOffset
             if (bufferRemainSize >= readRemainSize) {


### PR DESCRIPTION
Fix an oversight, which can cause an array out of bounds error when reading a file from a random position or fetching data that exceeds the total buffer capacity at one time.

Solve #20