### PR TITLE
close guest login issue

### DIFF
--- a/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/CifsClient.kt
+++ b/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/CifsClient.kt
@@ -34,11 +34,14 @@ class CifsClient @Inject constructor() {
             setProperty("jcifs.smb.client.responseTimeout", READ_TIMEOUT.toString())
             setProperty("jcifs.smb.client.connTimeout", CONNECTION_TIMEOUT.toString())
             setProperty("jcifs.smb.client.dfs.disabled", (!enableDfs).toString())
+            setProperty("jcifs.smb.client.ipcSigningEnforced", (!user.isNullOrEmpty() && !user.equals("guest")).toString())
+            setProperty("jcifs.smb.client.guestUsername", "cifs-documents-provider")
         }
 
         val context = BaseContext(PropertyConfiguration(property)).let {
             when {
                 anonymous -> it.withAnonymousCredentials() // Anonymous
+                user.isNullOrEmpty() -> it.withGuestCrendentials() // Guest if empty username
                 else -> it.withCredentials(NtlmPasswordAuthenticator(domain, user, password, null))
             }
         }


### PR DESCRIPTION
Added a logic to use the username entered by the user as the guest username when the user enters a username but does not enter a password.

In this case, `SpnegoIntegrity` is disabled, although I don't actually know what it means.

solve #24.