### PR TITLE
Foreground Service. Fix Issue #52

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <application
         android:name=".App"
@@ -40,6 +43,18 @@
             </intent-filter>
 
         </activity>
+
+        <receiver
+            android:name=".presentation.foreground_service.AutoStartReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
+
+        <service android:name=".presentation.foreground_service.RunningService" />
 
         <service android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/App.kt
+++ b/app/src/main/java/com/wa2c/android/cifsdocumentsprovider/App.kt
@@ -1,6 +1,9 @@
 package com.wa2c.android.cifsdocumentsprovider
 
 import android.app.Application
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
 import com.wa2c.android.cifsdocumentsprovider.common.utils.initLog
 import com.wa2c.android.cifsdocumentsprovider.data.BuildConfig
 import com.wa2c.android.cifsdocumentsprovider.domain.repository.AppRepository
@@ -16,6 +19,16 @@ class App: Application() {
 
     override fun onCreate() {
         super.onCreate()
+
+        val channel = NotificationChannel(
+            "running_channel",
+            "Running Notification",
+            NotificationManager.IMPORTANCE_LOW
+        )
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManager.createNotificationChannel(channel)
+
         initLog(BuildConfig.DEBUG)
         runBlocking {
             repository.migrate()

--- a/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/preference/AppPreferencesDataStore.kt
+++ b/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/preference/AppPreferencesDataStore.kt
@@ -60,6 +60,12 @@ internal class AppPreferencesDataStore @Inject constructor(
     /** Use as local */
     suspend fun setUseAsLocal(value: Boolean) = dataStore.setValue(PREFKEY_USE_AS_LOCAL, value)
 
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    val useForegroundServiceFlow: Flow<Boolean> = dataStore.data.map { it[PREFKEY_USE_FOREGROUND_SERVICE] ?: false }
+
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    suspend fun setUseForegroundService(value: Boolean) = dataStore.setValue(PREFKEY_USE_FOREGROUND_SERVICE, value)
+
     /** Temporary connection */
     val temporaryConnectionJsonFlow: Flow<String?> = dataStore.data.map { it[PREFKEY_TEMPORARY_CONNECTION_JSON]?.let { ConnectionUtils.decrypt(it) } }
 
@@ -98,6 +104,7 @@ internal class AppPreferencesDataStore @Inject constructor(
         private val PREFKEY_UI_THEME = stringPreferencesKey("prefkey_ui_theme")
         private val PREFKEY_OPEN_FILE_LIMIT = intPreferencesKey("prefkey_open_file_limit")
         private val PREFKEY_USE_AS_LOCAL = booleanPreferencesKey("prefkey_use_as_local")
+        private val PREFKEY_USE_FOREGROUND_SERVICE = booleanPreferencesKey("prefkey_use_foreground_service")
         private val PREFKEY_TEMPORARY_CONNECTION_JSON = stringPreferencesKey("prefkey_temporary_connection_json")
     }
 

--- a/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/AppRepository.kt
+++ b/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/AppRepository.kt
@@ -31,6 +31,12 @@ class AppRepository @Inject internal constructor(
     /** Use as local */
     suspend fun setUseAsLocal(value: Boolean) = appPreferences.setUseAsLocal(value)
 
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    val useForegroundServiceFlow = appPreferences.useForegroundServiceFlow
+
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    suspend fun setUseForegroundService(value: Boolean) = appPreferences.setUseForegroundService(value)
+
     /**
      * Migrate
      */

--- a/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt
+++ b/data/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/repository/CifsRepository.kt
@@ -45,6 +45,9 @@ class CifsRepository @Inject internal constructor(
     /** Use as local */
     val useAsLocalFlow = appPreferences.useAsLocalFlow
 
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    val useForegroundServiceFlow = appPreferences.useForegroundServiceFlow
+
     /** Connection flow */
     val connectionListFlow = connectionSettingDao.getList().map { list ->
         list.map { it.toModel() }

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/foreground_service/AutoStartReceiver.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/foreground_service/AutoStartReceiver.kt
@@ -1,0 +1,20 @@
+package com.wa2c.android.cifsdocumentsprovider.presentation.foreground_service
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.ContextCompat
+
+class AutoStartReceiver : BroadcastReceiver() {
+    override fun onReceive(p0: Context?, p1: Intent?) {
+        if (p0 != null) {
+            // from RunningService class, we check if the option is enabled,
+            // and only then activate the service, this is necessary since we can
+            // start the service either when the app open (MainActivity) or
+            // when device finishes booting (here).
+            val intent = Intent(p0, RunningService::class.java)
+            intent.action = RunningService.Actions.START.toString()
+            ContextCompat.startForegroundService(p0, intent)
+        }
+    }
+}

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/foreground_service/RunningService.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/foreground_service/RunningService.kt
@@ -1,0 +1,60 @@
+package com.wa2c.android.cifsdocumentsprovider.presentation.foreground_service
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import com.wa2c.android.cifsdocumentsprovider.domain.repository.CifsRepository
+import com.wa2c.android.cifsdocumentsprovider.presentation.PresentationModule
+import com.wa2c.android.cifsdocumentsprovider.presentation.R
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+
+class RunningService : Service() {
+    override fun onBind(p0: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // If use Foreground Service enabled, then activate the service, otherwise cancel it.
+        val cifsRepository: CifsRepository by lazy {
+            val clazz = PresentationModule.DocumentsProviderEntryPoint::class.java
+            val hiltEntryPoint = EntryPointAccessors.fromApplication(applicationContext, clazz)
+            hiltEntryPoint.getCifsRepository()
+        }
+        val useForegroundService = runBlocking { cifsRepository.useForegroundServiceFlow.first() }
+        if ( !useForegroundService ) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        when (intent?.action) {
+            Actions.START.toString() -> start()
+            Actions.STOP.toString() -> stopSelf()
+        }
+        super.onStartCommand(intent, flags, startId)
+        return START_STICKY
+    }
+
+    private fun start() {
+            // activate the foreground service
+            val notification = NotificationCompat.Builder(this, "running_channel")
+                .setSmallIcon(R.mipmap.ic_launcher)
+                .setContentTitle("Service is active..")
+                .setOngoing(true)
+                .setContentText("CIFS Document Provider")
+                .setStyle(
+                    NotificationCompat.InboxStyle()
+                        .addLine("Maintain process continuity")
+                        .addLine("to avoid sudden termination")
+                        .addLine("by Android OS while being")
+                        .addLine("used by other applications."))
+                .build()
+            startForeground(1, notification)
+    }
+
+    enum class Actions {
+        START, STOP
+    }
+}

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/MainActivity.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/MainActivity.kt
@@ -1,7 +1,9 @@
 package com.wa2c.android.cifsdocumentsprovider.presentation.ui
 
+import android.Manifest
 import android.content.Intent
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
@@ -9,11 +11,13 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.core.app.ActivityCompat
 import androidx.core.util.Consumer
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.wa2c.android.cifsdocumentsprovider.common.utils.mimeType
+import com.wa2c.android.cifsdocumentsprovider.presentation.foreground_service.RunningService
 import com.wa2c.android.cifsdocumentsprovider.presentation.ext.collectIn
 import com.wa2c.android.cifsdocumentsprovider.presentation.ext.mode
 import com.wa2c.android.cifsdocumentsprovider.presentation.notification.SendNotification
@@ -38,6 +42,19 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // request notification permission for the first time if not enabled.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ActivityCompat.requestPermissions(this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                0)
+        }
+        // from RunningService class, we check if the option is enabled,
+        // and only then activate the service, this is necessary since we can
+        // start the service either when the app open (here) or
+        // when device finishes booting.
+        val intent = Intent(applicationContext, RunningService::class.java)
+        intent.action = RunningService.Actions.START.toString()
+        startService(intent)
 
         AppCompatDelegate.setDefaultNightMode(mainViewModel.uiThemeFlow.value.mode) // Set theme
 

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsScreen.kt
@@ -79,6 +79,7 @@ fun SettingsScreen(
     val theme = viewModel.uiThemeFlow.collectAsStateWithLifecycle(UiTheme.DEFAULT)
     val openFileLimit = viewModel.openFileLimitFlow.collectAsStateWithLifecycle(OPEN_FILE_LIMIT_DEFAULT)
     val useAsLocal = viewModel.useAsLocalFlow.collectAsStateWithLifecycle(false)
+    val useForegroundService = viewModel.useForegroundServiceFlow.collectAsStateWithLifecycle(false)
     val showLibraries = remember { mutableStateOf(false) }
 
     SettingsScreenContainer(
@@ -96,6 +97,8 @@ fun SettingsScreen(
         onSetOpenFileLimit = { viewModel.setOpenFileLimit(it) },
         useAsLocal = useAsLocal.value,
         onSetUseAsLocal = { viewModel.setUseAsLocal(it) },
+        useForegroundService = useForegroundService.value,
+        onSetUseForegroundService = { viewModel.setUseForegroundService(it) },
         showLibraries = showLibraries.value,
         onClickLibraries = {
             showLibraries.value = true
@@ -139,6 +142,8 @@ private fun SettingsScreenContainer(
     onSetOpenFileLimit: (Int) -> Unit,
     useAsLocal: Boolean,
     onSetUseAsLocal: (Boolean) -> Unit,
+    useForegroundService: Boolean,
+    onSetUseForegroundService: (Boolean) -> Unit,
     showLibraries: Boolean,
     onClickLibraries: () -> Unit,
     onStartIntent: (Intent) -> Unit,
@@ -182,6 +187,8 @@ private fun SettingsScreenContainer(
                     onSetOpenFileLimit = onSetOpenFileLimit,
                     useAsLocal = useAsLocal,
                     onSetUseAsLocal = onSetUseAsLocal,
+                    useForegroundService = useForegroundService,
+                    onSetUseForegroundService = onSetUseForegroundService,
                     onShowLibraries = onClickLibraries,
                     onStartIntent = onStartIntent,
                 )
@@ -206,6 +213,8 @@ private fun SettingsList(
     onSetOpenFileLimit: (Int) -> Unit,
     useAsLocal: Boolean,
     onSetUseAsLocal: (Boolean) -> Unit,
+    useForegroundService: Boolean,
+    onSetUseForegroundService: (Boolean) -> Unit,
     onShowLibraries: () -> Unit,
     onStartIntent: (Intent) -> Unit,
 ) {
@@ -248,6 +257,14 @@ private fun SettingsList(
             checked = useAsLocal,
         ) {
             onSetUseAsLocal(it)
+        }
+
+        // Use Foreground Service
+        SettingsCheckItem(
+            text = stringResource(R.string.settings_set_use_foreground_service),
+            checked = useForegroundService,
+        ) {
+            onSetUseForegroundService(it)
         }
 
         // Information Title

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsViewModel.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsViewModel.kt
@@ -31,7 +31,13 @@ class SettingsViewModel @Inject constructor(
     /** Use as local */
     val useAsLocalFlow = appRepository.useAsLocalFlow
 
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    val useForegroundServiceFlow = appRepository.useForegroundServiceFlow
+
     /** Use as local */
     fun setUseAsLocal(value: Boolean) = launch { appRepository.setUseAsLocal(value) }
+
+    /** Use foreground service to make the app resilient to closing by Android OS */
+    fun setUseForegroundService(value: Boolean) = launch { appRepository.setUseForegroundService(value)}
 
 }

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -106,5 +106,6 @@
     <string name="enum_theme_default">Default</string>
     <string name="enum_theme_light">Light</string>
     <string name="enum_theme_dark">Dark</string>
+    <string name="settings_set_use_foreground_service">Use foreground service\n(App restart required)</string>
 
 </resources>


### PR DESCRIPTION
Fix Issue #52 

- Add foreground service to prevent sudden termination of CIFS Document Provider app while being used by other apps.
- Add option to enable the foreground service
- Auto start the service if enabled when the device finishes booting (low priority).
- Ask the user to allow notification for the first use, for foreground service to work, this is necessary.
- Added an explanation about the foreground service in the notification.

![Screenshot_20231025_175259_CIFS Documents Provider](https://github.com/wa2c/cifs-documents-provider/assets/1888186/7d700ce6-8ef2-4735-b0b3-3d92293be8ca)
