### PR TITLE
Add Arabic language and make Settings screen scrollable.

### DIFF
--- a/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Language.kt
+++ b/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Language.kt
@@ -13,6 +13,8 @@ enum class Language(
     ENGLISH("en"),
     /** Japanese */
     JAPANESE("ja"),
+    /** Arabic */
+    ARABIC("ar"),
     /** Slovak */
     SLOVAK("sk"),
     /** Chinese */

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ext/ValueResource.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ext/ValueResource.kt
@@ -62,6 +62,7 @@ fun Language.getLabel(context: Context): String {
     return when (this) {
         Language.ENGLISH -> R.string.enum_language_en
         Language.JAPANESE-> R.string.enum_language_ja
+        Language.ARABIC -> R.string.enum_language_ar
         Language.SLOVAK -> R.string.enum_language_sk
         Language.CHINESE -> R.string.enum_language_zh_rcn
     }.let {

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsScreen.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/settings/SettingsScreen.kt
@@ -8,13 +8,13 @@ import androidx.activity.compose.BackHandler
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -48,8 +48,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mikepenz.aboutlibraries.ui.compose.LibrariesContainer
 import com.mikepenz.aboutlibraries.ui.compose.LibraryDefaults
-import com.wa2c.android.cifsdocumentsprovider.common.values.OPEN_FILE_LIMIT_DEFAULT
 import com.wa2c.android.cifsdocumentsprovider.common.values.Language
+import com.wa2c.android.cifsdocumentsprovider.common.values.OPEN_FILE_LIMIT_DEFAULT
 import com.wa2c.android.cifsdocumentsprovider.common.values.UiTheme
 import com.wa2c.android.cifsdocumentsprovider.presentation.R
 import com.wa2c.android.cifsdocumentsprovider.presentation.ext.getLabel
@@ -219,77 +219,79 @@ private fun SettingsList(
     onStartIntent: (Intent) -> Unit,
 ) {
     val context = LocalContext.current
+    // Scrollable container
+    LazyColumn {
+        // Screen
+        item {
+            // Settings Title
+            TitleItem(text = stringResource(id = R.string.settings_section_set))
 
-    // Screen
-    Column {
-        // Settings Title
-        TitleItem(text = stringResource(id = R.string.settings_section_set))
+            // UI Theme
+            SettingsSingleChoiceItem(
+                title = stringResource(id = R.string.settings_set_theme),
+                items = UiTheme.values().map { it.getLabel(context) }.toList(),
+                selectedIndex = UiTheme.values().indexOf(theme),
+            ) {
+                onSetUiTheme(UiTheme.findByIndexOrDefault(it))
+            }
 
-        // UI Theme
-        SettingsSingleChoiceItem(
-            title = stringResource(id = R.string.settings_set_theme),
-            items = UiTheme.values().map { it.getLabel(context) }.toList(),
-            selectedIndex = UiTheme.values().indexOf(theme),
-        ) {
-            onSetUiTheme(UiTheme.findByIndexOrDefault(it))
-        }
+            // Language
+            SettingsSingleChoiceItem(
+                title = stringResource(id = R.string.settings_set_language),
+                items = Language.values().map { it.getLabel(context) }.toList(),
+                selectedIndex = Language.values().indexOf(language),
+            ) {
+                onSetLanguage(Language.findByIndexOrDefault(it))
+            }
 
-        // Language
-        SettingsSingleChoiceItem(
-            title = stringResource(id = R.string.settings_set_language),
-            items = Language.values().map { it.getLabel(context) }.toList(),
-            selectedIndex = Language.values().indexOf(language),
-        ) {
-            onSetLanguage(Language.findByIndexOrDefault(it))
-        }
+            // Open File Limit
+            SettingsInputNumberItem(
+                text = stringResource(id = R.string.settings_open_file_limit),
+                value = openFileLimit,
+            ) {
+                onSetOpenFileLimit(it)
+            }
 
-        // Open File Limit
-        SettingsInputNumberItem(
-            text = stringResource(id = R.string.settings_open_file_limit),
-            value = openFileLimit,
-        ) {
-            onSetOpenFileLimit(it)
-        }
+            // Use Foreground Service
+            SettingsCheckItem(
+                text = stringResource(R.string.settings_set_use_foreground),
+                checked = useForeground,
+            ) {
+                onSetUseForeground(it)
+            }
 
-        // Use Foreground Service
-        SettingsCheckItem(
-            text = stringResource(R.string.settings_set_use_foreground),
-            checked = useForeground,
-        ) {
-            onSetUseForeground(it)
-        }
+            // Use Local
+            SettingsCheckItem(
+                text = stringResource(id = R.string.settings_set_use_as_local),
+                checked = useAsLocal,
+            ) {
+                onSetUseAsLocal(it)
+            }
 
-        // Use Local
-        SettingsCheckItem(
-            text = stringResource(id = R.string.settings_set_use_as_local),
-            checked = useAsLocal,
-        ) {
-            onSetUseAsLocal(it)
-        }
+            // Information Title
+            TitleItem(text = stringResource(id = R.string.settings_section_info))
 
-        // Information Title
-        TitleItem(text = stringResource(id = R.string.settings_section_info))
+            // Libraries
+            SettingsItem(text = stringResource(id = R.string.settings_info_libraries)) {
+                onShowLibraries()
+            }
 
-        // Libraries
-        SettingsItem(text = stringResource(id = R.string.settings_info_libraries)) {
-            onShowLibraries()
-        }
-
-        // Contributors
-        SettingsItem(text = stringResource(id = R.string.settings_info_contributors)) {
-            onStartIntent(
-                Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/wa2c/cifs-documents-provider/graphs/contributors"))
-            )
-        }
-
-        // App
-        SettingsItem(text = stringResource(id = R.string.settings_info_app)) {
-            onStartIntent(
-                Intent(
-                    Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-                    Uri.parse("package:" + context.packageName)
+            // Contributors
+            SettingsItem(text = stringResource(id = R.string.settings_info_contributors)) {
+                onStartIntent(
+                    Intent(Intent.ACTION_VIEW, Uri.parse("https://github.com/wa2c/cifs-documents-provider/graphs/contributors"))
                 )
-            )
+            }
+
+            // App
+            SettingsItem(text = stringResource(id = R.string.settings_info_app)) {
+                onStartIntent(
+                    Intent(
+                        Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                        Uri.parse("package:" + context.packageName)
+                    )
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_summary">.الوصول إلى المجلدات المشتركة</string>
+    <string name="dialog_accept">حسنا</string>
+    <string name="dialog_close">إغلاق</string>
+
+    <!-- Home Screen -->
+    <string name="home_open_file">فتح</string>
+    <string name="home_open_settings">الإعدادات</string>
+    <string name="home_open_file_ng_message">أضف أي إتصال</string>
+    <string name="home_add_connection_a11y">أضف</string>
+
+    <!-- Edit Screen -->
+    <string name="edit_title">إتصال</string>
+    <string name="edit_name_title">الإسم</string>
+    <string name="edit_name_hint">إسم المضيف إذا كان خاليا</string>
+    <string name="edit_storage_title">التخزين (نوع المكتبة)</string>
+    <string name="edit_domain_title">النطاق</string>
+    <string name="edit_domain_hint">الإدخال حسب الحاجة</string>
+    <string name="edit_host_title">المضيف</string>
+    <string name="edit_host_hint">عنوان ال ( آي بي ) للمضيف / الخادم</string>
+    <string name="edit_host_select_a11y">تصفح</string>
+    <string name="edit_port_title">بوابة</string>
+    <string name="edit_port_hint">أهمل إن كان خاليا</string>
+    <string name="edit_enable_dfs_label">فعّل - دي إف أس - ( نظام الملفات الموزعة )</string>
+    <string name="edit_folder_title">المجلد</string>
+    <string name="edit_folder_hint">\'/\' إذا كان خاليا</string>
+    <string name="edit_directory_search_a11y">تصفح</string>
+    <string name="edit_user_title">المستخدم</string>
+    <string name="edit_user_hint">باطل إذا كان مجهول</string>
+    <string name="edit_password_title">كلمة المرور</string>
+    <string name="edit_password_hint">باطل إذا كان مجهول</string>
+    <string name="edit_anonymous_label">مجهول</string>
+    <string name="edit_option_title">خيار</string>
+    <string name="edit_option_extension_label">أضف وصلة عند الحفظ</string>
+    <string name="edit_option_safe_transfer_label">نقل بيانات آمن</string>
+    <string name="edit_connection_uri_title">عنوان ال ( أس أم بي ) </string>
+    <string name="edit_provider_uri_title">عنوان التشارك</string>
+    <string name="edit_check_connection_button">فحص الاتصال</string>
+    <string name="edit_check_connection_ok_message">نجح الاتصال</string>
+    <string name="edit_check_connection_wn_message">الإعدادات فيها خطأ</string>
+    <string name="edit_check_connection_ng_message">فشل الإتصال</string>
+    <string name="edit_save_ng_message">أدخل المضيف ( الخادم )</string>
+    <string name="edit_save_duplicate_message">العنوان مكرر</string>
+    <string name="edit_save_button">حفظ</string>
+    <string name="edit_delete_button">حذف</string>
+    <string name="edit_back_confirmation_message">أهمل التغييرات؟</string>
+    <string name="edit_delete_confirmation_message">إحذف الإعدادات؟</string>
+
+    <!-- Host Screen -->
+    <string name="host_title">المضيف</string>
+    <string name="host_set_manually">تحديد يدويا</string>
+    <string name="host_select_confirmation_message">أدخل البيانات المختارة لتعديل عليها في الأنموذج</string>
+    <string name="host_select_host_name">إسم المضيف</string>
+    <string name="host_select_ip_address">عنوان ال ( آي بي )</string>
+    <string name="host_sort_button">فرز</string>
+    <string name="host_reload_button">إعادة تحميل</string>
+    <string name="host_sort_type_detection_ascend">تحرى (تصاعديا)</string>
+    <string name="host_sort_type_detection_descend">تحرى (تنازليا)</string>
+    <string name="host_sort_type_host_name_ascend">إسم المضيف (تصاعديا)</string>
+    <string name="host_sort_type_host_name_descend">إسم المضيف (تنازليا)</string>
+    <string name="host_sort_type_ip_address_ascend">عنوان ال ( آي بي ) (تصاعديا)</string>
+    <string name="host_sort_type_ip_address_descend">عنوان ال ( آي بي ) (تنازليا)</string>
+    <string name="host_error_network">@string/provider_error_message</string>
+
+    <!-- Folder Screen -->
+    <string name="folder_title">مجلد</string>
+    <string name="folder_set">حدد المجلد</string>
+    <string name="folder_reload_button">إعادة تحميل</string>
+    <string name="folder_list_empty">لا مجلدات فرعية</string>
+
+    <!-- Settings Screen -->
+    <string name="settings_title">الإعدادات</string>
+    <string name="settings_section_set">الإعدادات</string>
+    <string name="settings_set_theme">الهيئة</string>
+    <string name="settings_set_language">اللغة</string>
+    <string name="settings_open_file_limit">تحديد الملفات المفتوحة\n(يجب إعادة تشغيل التطبيق)</string>
+    <string name="settings_set_use_foreground">أظهر الإشعارات عند فتح الملفات</string>
+    <string name="settings_set_use_as_local">محاكاة الذاكرة المحلية\n(مطلوب إعادة تشغيل الجهاز)</string>
+    <string name="settings_section_info">معلومات</string>
+    <string name="settings_info_contributors">المساهمين</string>
+    <string name="settings_info_libraries">المكتبات</string>
+    <string name="settings_info_app">التطبيق</string>
+
+    <!-- Send Screen -->
+    <string name="send_title">نقل الملف</string>
+    <string name="send_close_button">إغلاق</string>
+    <string name="send_action_cancel">إلغاء</string>
+    <string name="send_action_retry">إعادة محاولة</string>
+    <string name="send_action_remove">إزالة</string>
+    <string name="send_state_ready">جاهز</string>
+    <string name="send_state_overwrite">الملف موجود</string>
+    <string name="send_state_success">نجاح</string>
+    <string name="send_state_failure">فشل</string>
+    <string name="send_state_cancel">ملغى</string>
+    <string name="send_exit_confirmation_message">إلغاء كل عمليات النقل و الخروج من التطبيق</string>
+    <string name="send_overwrite_confirmation_message">(استبدال الملفات) Overwrite %1$d files.</string>
+
+    <!-- DocumentsProvider -->
+    <string name="provider_error_message">حصل خطأ ما</string>
+
+    <!-- Notification -->
+    <string name="notification_channel_name_provider">فتح ملف</string>
+    <string name="notification_title_provider">عملية فتح الملف</string>
+    <string name="notification_channel_name_send">نقل البيانات</string>
+    <string name="notification_title_send_completed">تمام</string>
+
+    <!-- Theme Enum -->
+    <string name="enum_theme_default">الوضع الطبيعي</string>
+    <string name="enum_theme_light">نهاري</string>
+    <string name="enum_theme_dark">ليلي</string>
+
+</resources>

--- a/presentation/src/main/res/values/strings-common.xml
+++ b/presentation/src/main/res/values/strings-common.xml
@@ -7,6 +7,7 @@
 
     <string name="enum_language_en">English</string>
     <string name="enum_language_ja">日本語</string>
+    <string name="enum_language_ar">العربية</string>
     <string name="enum_language_sk">Slovenský</string>
     <string name="enum_language_zh_rcn">简体中文</string>
 

--- a/presentation/src/main/res/xml/locales_config.xml
+++ b/presentation/src/main/res/xml/locales_config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+    <locale android:name="ar" />
     <locale android:name="en" />
     <locale android:name="ja" />
     <locale android:name="sk" />


### PR DESCRIPTION
- Add Arabic language, the app surprisingly works very well with Right-To-Left (RTL) languages 👍
- Make `Settings` screen scrollable using swipe gesture or mouse wheel.

Before this, if the screen is too small or the user applied text enlargement
from Android's Accessibility. Then some items in the `Settings` screen, well,
might not be shown and be off the screen.

Now it doesn't care about the screen size, the user can scroll using
swipe gesture / mouse.scroll wheel.