### PR TITLE
Return 0 bytes read at End of File instead of -1 for safe functions.

### DIFF
--- a/data/storage/jcifs/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifs/JCifsProxyFileCallbackSafe.kt
+++ b/data/storage/jcifs/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifs/JCifsProxyFileCallbackSafe.kt
@@ -59,7 +59,8 @@ internal class JCifsProxyFileCallbackSafe(
     override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
         return processFileIo(coroutineContext) {
             access.seek(offset)
-            access.read(data, 0, size)
+            // if End-Of-File (-1) then return 0 bytes read
+            maxOf(0, access.read(data, 0, size))
         }
     }
 

--- a/data/storage/jcifsng/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifsng/JCifsNgProxyFileCallbackSafe.kt
+++ b/data/storage/jcifsng/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifsng/JCifsNgProxyFileCallbackSafe.kt
@@ -59,7 +59,8 @@ internal class JCifsNgProxyFileCallbackSafe(
     override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
         return processFileIo(coroutineContext) {
             access.seek(offset)
-            access.read(data, 0, size)
+            // if End-Of-File (-1) then return 0 bytes read
+            maxOf(0, access.read(data, 0, size))
         }
     }
 

--- a/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjProxyFileCallbackSafe.kt
+++ b/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjProxyFileCallbackSafe.kt
@@ -34,7 +34,8 @@ class SmbjProxyFileCallbackSafe(
     @Throws(ErrnoException::class)
     override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
         return processFileIo(coroutineContext) {
-            file.read(data, offset, 0, size)
+            // if End-Of-File (-1) then return 0 bytes read
+            maxOf(0,file.read(data, offset, 0, size))
         }
     }
 


### PR DESCRIPTION
This is for (JCIFS, JCIFSNG, or SMBJ)ProxyFileCallbackSafe. The none safe `onRead()` functions return 0 bytes read at EOF. But I noticed SMBJ and JCIFS-NG (safe `onRead()`) return -1 to indicate EOF.

This causes lots of problems. The app trying to read a file might not expect to see -1 (wrapped to 4GB if 32bit) to be read and complains that the file size is not expected and too big.

Without this fix, an exception would have been thrown, a very long exception with stack trace error log. CIFS Document Provider completely crashes, and then afterwards, the notification of `"Opening file"` shows up and there is no file opened. I had to force close CIFS Document Provider then.

I am not sure about JCIFS (SMBv1), since my TrueNAS server doesn't support SMBv1, I can't test it. But I assume it would be the same, since JAVA usually returns -1 for end of file. I tested SMBJ and JCIFS-NG, which both had the same issue.

The program I used for testing, AetherSX2 loading BIOS file either `SCPH10000.bin` or `SCPH39001.bin` would trigger the issue. Which only happens on Safe transfers enabled. Below are screenshots of the logcat before and after.

The solution might not be optimal, feel free to modify as you like.