### PR TITLE
Fix notifications.

### DIFF
--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/worker/ProviderNotification.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/worker/ProviderNotification.kt
@@ -17,7 +17,7 @@ import com.wa2c.android.cifsdocumentsprovider.presentation.R
 /**
  * Provider Notification
  */
-class ProviderNotification constructor(
+class ProviderNotification(
     private val context: Context,
 ) {
     /** Notification manager */
@@ -57,6 +57,7 @@ class ProviderNotification constructor(
             .setOngoing(true)
             .setSmallIcon(R.drawable.ic_notification)
             .setContentTitle(context.getString(R.string.notification_title_provider))
+            .setForegroundServiceBehavior(NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE)
             .setStyle(
                 NotificationCompat.InboxStyle().also { style ->
                     list.map { it.getFileName(context) }.filter { it.isNotBlank() }.forEach { style.addLine(it) }
@@ -81,7 +82,7 @@ class ProviderNotification constructor(
      * Update notification
      */
     fun updateNotification(list: List<Uri>) {
-        if (!notificationManager.activeNotifications.any { it.id == NOTIFICATION_ID_PROVIDER }) return
+        if (list.isEmpty()) return
         val notification = createNotification(list)
         notificationManager.notify(NOTIFICATION_ID_PROVIDER, notification)
     }

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/worker/ProviderWorker.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/worker/ProviderWorker.kt
@@ -1,6 +1,8 @@
 package com.wa2c.android.cifsdocumentsprovider.presentation.worker
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.coroutineScope
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
@@ -24,6 +26,7 @@ class ProviderWorker(
     private val cifsRepository: CifsRepository by lazy { provideCifsRepository(context) }
     private val lifecycleOwner = WorkerLifecycleOwner()
     private var deferredUntilCompleted = CompletableDeferred<Unit>()
+    private val handler = Handler(Looper.getMainLooper())
 
     override suspend fun doWork(): Result {
         logD("ProviderWorker begin")
@@ -33,11 +36,20 @@ class ProviderWorker(
             lifecycleOwner.lifecycle.coroutineScope.launch {
                 cifsRepository.openUriList.collectIn(lifecycleOwner) { list ->
                     providerNotification.updateNotification(list)
+                    val completeRunnable = Runnable {
+                        // don't use list here, 5 seconds later the real list could be different
+                        if (cifsRepository.openUriList.value.isEmpty()) deferredUntilCompleted.complete(Unit)
+                        else  providerNotification.updateNotification(cifsRepository.openUriList.value)
+                    }
                     if (list.isEmpty()) {
-                        deferredUntilCompleted.complete(Unit)
+                        // Check again after grace period, if list is empty cancel work.
+                        // otherwise, sometimes notification gets canceled as soon as opened
+                        handler.removeCallbacks(completeRunnable)
+                        handler.postDelayed(completeRunnable, 5000)
                     }
                 }
             }
+
             setForeground(providerNotification.getNotificationInfo(cifsRepository.openUriList.value))
             deferredUntilCompleted.await() // wait until the uri list is empty.
         } catch (e: CancellationException) {


### PR DESCRIPTION
If the opened file URIs list is empty then check again after grace period. If list is empty cancel work. otherwise, most notification gets canceled as soon as opened

This is to ensure there is no sync issues between threads, the list is reported empty when it is clearly not empty! But when we check again after few seconds, the list correctly reports the opened files. If it was indeed empty, then cancel work by `deferredUntilCompleted.complete(Unit)`.

I opted to use `Handler(Looper.getMainLooper()).postDelayed()` instead of `Timer`. The Handler uses the main applications thread, while the Timer creates a background thread to call the deferred work. I didn't notice much difference between both, but Handler is safer if we are checking the value of StateFlow `cifsRepository.openUriList.value` since if we did that in a background thread, that might cause race conditions and sync issues between threads.

And since WorkManager automatically runs it on a background thread, that might have caused a race condition when checking the state flow. This is just a guess.

Anyways. This fixes the notifications, and has no bad side effects after extensive testing.