### PR TITLE
Auto-Switch between Native and Buffered modes for SMBJ and jCIFS-NG, new option for SMB connection and big performance improvement.

### DIFF
--- a/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Const.kt
+++ b/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Const.kt
@@ -14,7 +14,7 @@ const val DEFAULT_ENCODING = "UTF-8"
 
 const val CONNECTION_TIMEOUT = 10000
 const val READ_TIMEOUT = 10000
-const val BUFFER_SIZE = 1024 * 1024
+const val BUFFER_SIZE = 512 * 1024
 const val CACHE_TIMEOUT = 300 * 1000
 const val OPEN_FILE_LIMIT_DEFAULT = 30
 const val OPEN_FILE_LIMIT_MIN = 1

--- a/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Const.kt
+++ b/common/src/main/java/com/wa2c/android/cifsdocumentsprovider/common/values/Const.kt
@@ -14,7 +14,7 @@ const val DEFAULT_ENCODING = "UTF-8"
 
 const val CONNECTION_TIMEOUT = 10000
 const val READ_TIMEOUT = 10000
-const val BUFFER_SIZE = 512 * 1024
+const val BUFFER_SIZE = 1024 * 1024
 const val CACHE_TIMEOUT = 300 * 1000
 const val OPEN_FILE_LIMIT_DEFAULT = 30
 const val OPEN_FILE_LIMIT_MIN = 1

--- a/data/storage/interfaces/build.gradle.kts
+++ b/data/storage/interfaces/build.gradle.kts
@@ -24,6 +24,9 @@ android {
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion
     }
+    kotlinOptions {
+        freeCompilerArgs = listOf("-XXLanguage:+BreakContinueInInlineLambdas")
+    }
 
     kotlin {
         jvmToolchain {

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/StorageConnection.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/StorageConnection.kt
@@ -61,6 +61,7 @@ sealed class StorageConnection {
         val domain: String?,
         val enableDfs: Boolean,
         val enableEncryption: Boolean = false,
+        val enableSecuritySignature: Boolean = true,
     ) : StorageConnection()
 
     /**

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/StorageConnection.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/StorageConnection.kt
@@ -61,7 +61,9 @@ sealed class StorageConnection {
         val domain: String?,
         val enableDfs: Boolean,
         val enableEncryption: Boolean = false,
-        val enableSecuritySignature: Boolean = true,
+        // true for SMBJ and false for jCIFS-NG
+        val enableSmbjSecuritySignature: Boolean = true,
+        val enableJcifsSecuritySignature: Boolean = false,
     ) : StorageConnection()
 
     /**

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferReader.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferReader.kt
@@ -23,6 +23,7 @@
  */
 package com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils
 
+import com.wa2c.android.cifsdocumentsprovider.common.values.BUFFER_SIZE
 import kotlinx.coroutines.*
 import java.io.Closeable
 import java.util.concurrent.ConcurrentHashMap
@@ -143,7 +144,9 @@ class BackgroundBufferReader(
     )
 
     companion object {
-        private const val DEFAULT_BUFFER_SIZE = 512 * 1024 // 512 KB
-        private const val DEFAULT_CACHE_BLOCKS = 32        // ~16 MB cache
+        // 1MB / buffer
+        private const val DEFAULT_BUFFER_SIZE = BUFFER_SIZE
+        // 32 Buffers x 1MB = 32MB Total
+        private const val DEFAULT_CACHE_BLOCKS = 32
     }
 }

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferReader.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferReader.kt
@@ -146,7 +146,7 @@ class BackgroundBufferReader(
     companion object {
         // 1MB / buffer
         private const val DEFAULT_BUFFER_SIZE = BUFFER_SIZE
-        // 32 Buffers x 1MB = 32MB Total
+        // 32 buffers x 1MB = 32MB total
         private const val DEFAULT_CACHE_BLOCKS = 32
     }
 }

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferWriter.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferWriter.kt
@@ -25,143 +25,98 @@ package com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils
 
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logD
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logE
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.async
-import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.*
 import java.io.Closeable
 import java.nio.ByteBuffer
 import java.util.concurrent.ArrayBlockingQueue
 import kotlin.coroutines.CoroutineContext
 
-/**
- * BackgroundBufferReader
- */
 class BackgroundBufferWriter(
-    /** Buffer unit size */
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,
-    /** Buffer queue capacity  */
     private val queueCapacity: Int = DEFAULT_CAPACITY,
-    /** Coroutine context */
     override val coroutineContext: CoroutineContext = Dispatchers.IO + Job(),
-    /** Background writing */
     private val writeBackground: suspend CoroutineScope.(start: Long, array: ByteArray, off: Int, len: Int) -> Unit
-): CoroutineScope, Closeable {
-    /** Data buffer queue */
-    private val dataBufferQueue = ArrayBlockingQueue<WriteDataBuffer>(queueCapacity)
-    /** Current data buffer */
-    private var currentBuffer: WriteDataBuffer? = null
+) : CoroutineScope, Closeable {
 
-    /**
-     * Writing cycle task
-     */
-    private val writingCycleTask = async(coroutineContext) {
-        logD("[CYCLE] Begin: bufferSize=$bufferSize")
-        while (isActive) {
-            try {
-                val dataBuffer = dataBufferQueue.take()
-                if (dataBuffer.isEndOfData) {
-                    break
-                } else {
-                    logD("[CYCLE] Write: position=${dataBuffer.position}, length=${dataBuffer.length}")
-                    writeBackground(dataBuffer.position, dataBuffer.data.array(), 0, dataBuffer.length)
+    private val dataBufferQueue = ArrayBlockingQueue<WriteDataBuffer>(queueCapacity)
+    private var currentBuffer: WriteDataBuffer? = null
+    @Volatile private var closed = false
+
+    init {
+        launch(coroutineContext) {
+            logD("[CYCLE] Writer started")
+            while (isActive || dataBufferQueue.isNotEmpty()) {
+                val buffer = dataBufferQueue.poll() ?: continue
+                if (buffer.isEndOfData) break
+                try {
+                    writeBackground(buffer.position, buffer.data.array(), 0, buffer.length)
+                } catch (e: Exception) {
+                    logE(e)
                 }
-            } catch (e: Exception) {
-                logE(e)
             }
+            logD("[CYCLE] Writer ended")
         }
-        logD("[CYCLE] End")
     }
 
-    /**
-     * Write buffer
-     * @param writePosition Absolute data position.
-     * @param writeSize Required read data size.
-     * @param writeData For saving reading data.
-     */
     fun writeBuffer(writePosition: Long, writeSize: Int, writeData: ByteArray): Int {
-        // Check new position
+        if (closed) return -1
+
+        // Flush old buffer if discontinuous
         currentBuffer?.let {
             if (it.endPosition != writePosition) {
-                dataBufferQueue.put(it)
+                flushBuffer(it)
                 currentBuffer = null
             }
         }
 
-        if (writeSize > bufferSize) {
-            // writeSize lager than bufferSize
-            currentBuffer?.let { dataBufferQueue.put(it) }
-            dataBufferQueue.put(WriteDataBuffer(writePosition, ByteBuffer.wrap(writeData)))
-            currentBuffer = null
+        if (writeSize >= bufferSize) {
+            // Direct enqueue for large writes
+            flushBuffer(WriteDataBuffer(writePosition, ByteBuffer.wrap(writeData.copyOf(writeSize))))
+            return writeSize
+        }
+
+        val buffer = currentBuffer ?: WriteDataBuffer(writePosition, ByteBuffer.allocate(bufferSize))
+            .also { currentBuffer = it }
+
+        if (buffer.data.remaining() < writeSize) {
+            flushBuffer(buffer)
+            currentBuffer = WriteDataBuffer(writePosition, ByteBuffer.allocate(bufferSize))
+                .also { it.data.put(writeData, 0, writeSize) }
         } else {
-            currentBuffer?.let { buffer ->
-                if (buffer.data.remaining() >= writeSize) {
-                    buffer.data.put(writeData, 0, writeSize)
-                } else {
-                    dataBufferQueue.put(buffer)
-                    currentBuffer = null
-                }
-            }
-            if (currentBuffer == null){
-                currentBuffer = WriteDataBuffer(writePosition, ByteBuffer.allocate(bufferSize)).also {
-                    it.data.put(writeData, 0, writeSize)
-                }
-            }
+            buffer.data.put(writeData, 0, writeSize)
         }
 
         return writeSize
     }
 
-    /**
-     * Close
-     */
-    override fun close() {
-        logD("close")
-        runBlocking(coroutineContext) {
-            currentBuffer?.let {
-                // Put current buffer to queue
-                currentBuffer = null
-                dataBufferQueue.put(it)
-            }
-            // Put end flag to queue
-            dataBufferQueue.put(WriteDataBuffer.endOfData)
-            writingCycleTask.await()
-            logD("writingCycleTask completed")
+    private fun flushBuffer(buffer: WriteDataBuffer) {
+        // Non-blocking flush: if full, retry
+        while (!dataBufferQueue.offer(buffer)) {
+            Thread.sleep(1) // Yield to background writer
         }
     }
 
-    /**
-    * Data buffer
-    */
+    override fun close() {
+        closed = true
+        currentBuffer?.let { flushBuffer(it) }
+        dataBufferQueue.offer(WriteDataBuffer.endOfData)
+    }
+
     data class WriteDataBuffer(
-        /** Data absolute start position */
         val position: Long,
-        /** Data buffer */
         val data: ByteBuffer,
     ) {
-        /** Data length */
-        val length: Int
-            get() = data.position()
-
-        /** End position */
-        val endPosition: Long
-            get() = position + length
-
-        /** True if this is end of data. */
-        val isEndOfData: Boolean
-            get() = position < 0
+        val length: Int get() = data.position()
+        val endPosition: Long get() = position + length
+        val isEndOfData: Boolean get() = position < 0
 
         companion object {
-            /** End flag data */
             val endOfData = WriteDataBuffer(-1, ByteBuffer.allocate(0))
         }
     }
 
     companion object {
-        private const val DEFAULT_BUFFER_SIZE = 1024 * 1024
-        private const val DEFAULT_CAPACITY = 5
+        private const val DEFAULT_BUFFER_SIZE = 1024 * 1024 // 1MB
+        private const val DEFAULT_CAPACITY = 32 // Bigger queue to prevent stall
     }
-
 }

--- a/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferWriter.kt
+++ b/data/storage/interfaces/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/interfaces/utils/BackgroundBufferWriter.kt
@@ -25,98 +25,140 @@ package com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils
 
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logD
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logE
+import com.wa2c.android.cifsdocumentsprovider.common.values.BUFFER_SIZE
 import kotlinx.coroutines.*
 import java.io.Closeable
 import java.nio.ByteBuffer
 import java.util.concurrent.ArrayBlockingQueue
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * BackgroundBufferWriter - Optimized non-blocking writer
+ */
 class BackgroundBufferWriter(
+    /** Buffer unit size */
     private val bufferSize: Int = DEFAULT_BUFFER_SIZE,
+    /** Buffer queue capacity */
     private val queueCapacity: Int = DEFAULT_CAPACITY,
+    /** Coroutine context */
     override val coroutineContext: CoroutineContext = Dispatchers.IO + Job(),
-    private val writeBackground: suspend CoroutineScope.(start: Long, array: ByteArray, off: Int, len: Int) -> Unit
+    /** Background writing callback */
+    private val writeBackground: suspend CoroutineScope.(position: Long, array: ByteArray, off: Int, len: Int) -> Unit
 ) : CoroutineScope, Closeable {
 
+    /** Queue for pending writes */
     private val dataBufferQueue = ArrayBlockingQueue<WriteDataBuffer>(queueCapacity)
-    private var currentBuffer: WriteDataBuffer? = null
-    @Volatile private var closed = false
 
-    init {
-        launch(coroutineContext) {
-            logD("[CYCLE] Writer started")
-            while (isActive || dataBufferQueue.isNotEmpty()) {
-                val buffer = dataBufferQueue.poll() ?: continue
-                if (buffer.isEndOfData) break
-                try {
-                    writeBackground(buffer.position, buffer.data.array(), 0, buffer.length)
-                } catch (e: Exception) {
-                    logE(e)
+    /** Current write buffer */
+    private var currentBuffer: WriteDataBuffer? = null
+
+    /** Async background writer */
+    private val writingJob = launch(coroutineContext) {
+        logD("[WRITE-CYCLE] Begin: bufferSize=$bufferSize")
+        while (isActive) {
+            try {
+                val dataBuffer = dataBufferQueue.take()
+                if (dataBuffer.isEndOfData) break
+
+                // Only write if it has actual data
+                if (dataBuffer.length > 0) {
+                    logD("[WRITE-CYCLE] Writing: position=${dataBuffer.position}, length=${dataBuffer.length}")
+                    writeBackground(dataBuffer.position, dataBuffer.data.array(), 0, dataBuffer.length)
                 }
+            } catch (e: Exception) {
+                logE(e)
             }
-            logD("[CYCLE] Writer ended")
         }
+        logD("[WRITE-CYCLE] End")
     }
 
+    /**
+     * Write buffer (non-blocking)
+     */
     fun writeBuffer(writePosition: Long, writeSize: Int, writeData: ByteArray): Int {
-        if (closed) return -1
+        var remaining = writeSize
+        var offset = 0
 
-        // Flush old buffer if discontinuous
-        currentBuffer?.let {
-            if (it.endPosition != writePosition) {
-                flushBuffer(it)
+        while (remaining > 0) {
+            var buffer = currentBuffer
+
+            if (buffer == null || buffer.isFull || buffer.endPosition != writePosition + offset) {
+                // flush current buffer if exists
+                buffer?.let { enqueueBuffer(it) }
+
+                // create new buffer aligned at this position
+                buffer = WriteDataBuffer(writePosition + offset, ByteBuffer.allocate(bufferSize))
+                currentBuffer = buffer
+            }
+
+            val toCopy = minOf(remaining, buffer.data.remaining())
+            buffer.data.put(writeData, offset, toCopy)
+
+            offset += toCopy
+            remaining -= toCopy
+
+            if (buffer.isFull) {
+                enqueueBuffer(buffer)
                 currentBuffer = null
             }
-        }
-
-        if (writeSize >= bufferSize) {
-            // Direct enqueue for large writes
-            flushBuffer(WriteDataBuffer(writePosition, ByteBuffer.wrap(writeData.copyOf(writeSize))))
-            return writeSize
-        }
-
-        val buffer = currentBuffer ?: WriteDataBuffer(writePosition, ByteBuffer.allocate(bufferSize))
-            .also { currentBuffer = it }
-
-        if (buffer.data.remaining() < writeSize) {
-            flushBuffer(buffer)
-            currentBuffer = WriteDataBuffer(writePosition, ByteBuffer.allocate(bufferSize))
-                .also { it.data.put(writeData, 0, writeSize) }
-        } else {
-            buffer.data.put(writeData, 0, writeSize)
         }
 
         return writeSize
     }
 
-    private fun flushBuffer(buffer: WriteDataBuffer) {
-        // Non-blocking flush: if full, retry
-        while (!dataBufferQueue.offer(buffer)) {
-            Thread.sleep(1) // Yield to background writer
+    /**
+     * Enqueue a buffer for background writing
+     */
+    private fun enqueueBuffer(buffer: WriteDataBuffer) {
+        buffer.data.flip() // prepare for reading
+        dataBufferQueue.put(buffer)
+    }
+
+    /**
+     * Close the writer and flush everything
+     */
+    override fun close() {
+        logD("close() called, flushing buffers")
+        runBlocking(coroutineContext) {
+            currentBuffer?.let {
+                enqueueBuffer(it)
+                currentBuffer = null
+            }
+            // enqueue end signal
+            dataBufferQueue.put(WriteDataBuffer.endOfData)
+            writingJob.join()
+            logD("Writing job finished")
         }
     }
 
-    override fun close() {
-        closed = true
-        currentBuffer?.let { flushBuffer(it) }
-        dataBufferQueue.offer(WriteDataBuffer.endOfData)
-    }
-
+    /**
+     * Data buffer class
+     */
     data class WriteDataBuffer(
+        /** Start position in stream */
         val position: Long,
-        val data: ByteBuffer,
+        /** Byte buffer */
+        val data: ByteBuffer
     ) {
-        val length: Int get() = data.position()
-        val endPosition: Long get() = position + length
-        val isEndOfData: Boolean get() = position < 0
+        val length: Int
+            get() = data.position()
+        val endPosition: Long
+            get() = position + length
+        val isFull: Boolean
+            get() = !data.hasRemaining()
+        val isEndOfData: Boolean
+            get() = position < 0
 
         companion object {
+            /** End flag data */
             val endOfData = WriteDataBuffer(-1, ByteBuffer.allocate(0))
         }
     }
 
     companion object {
-        private const val DEFAULT_BUFFER_SIZE = 1024 * 1024 // 1MB
-        private const val DEFAULT_CAPACITY = 32 // Bigger queue to prevent stall
+        // 1MB / buffer
+        private const val DEFAULT_BUFFER_SIZE = BUFFER_SIZE
+        // 32 buffers x 1MB = 32MB total
+        private const val DEFAULT_CAPACITY = 32
     }
 }

--- a/data/storage/jcifsng/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifsng/JCifsNgClient.kt
+++ b/data/storage/jcifsng/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/jcifsng/JCifsNgClient.kt
@@ -91,6 +91,7 @@ class JCifsNgClient(
                 setProperty("jcifs.smb.client.minVersion", "SMB202")
                 setProperty("jcifs.smb.client.maxVersion", "SMB311")
             }
+            setProperty("jcifs.smb.client.signingPreferred", connection.enableJcifsSecuritySignature.toString())
             setProperty("jcifs.smb.client.responseTimeout", READ_TIMEOUT.toString())
             setProperty("jcifs.smb.client.connTimeout", CONNECTION_TIMEOUT.toString())
             setProperty("jcifs.smb.client.attrExpirationPeriod", CACHE_TIMEOUT.toString())

--- a/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
+++ b/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
@@ -31,6 +31,7 @@ import com.wa2c.android.cifsdocumentsprovider.common.utils.logE
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logW
 import com.wa2c.android.cifsdocumentsprovider.common.utils.throwStorageCommonException
 import com.wa2c.android.cifsdocumentsprovider.common.values.AccessMode
+import com.wa2c.android.cifsdocumentsprovider.common.values.BUFFER_SIZE
 import com.wa2c.android.cifsdocumentsprovider.common.values.OPEN_FILE_LIMIT_DEFAULT
 import com.wa2c.android.cifsdocumentsprovider.common.values.OPEN_FILE_LIMIT_MAX
 import com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.StorageClient
@@ -130,6 +131,7 @@ class SmbjClient(
                 }
             }
             configBuilder.withSigningEnabled(connection.enableSmbjSecuritySignature)
+            configBuilder.withBufferSize(BUFFER_SIZE)
 
             val config = configBuilder.build()
             val client = SMBClient(config)

--- a/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
+++ b/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
@@ -122,14 +122,14 @@ class SmbjClient(
                 // So, we opt for SMB dialect 2.x *ONLY* if both encryption and signing
                 // are both disabled. This resulting in a big speed boost ranging from 25%
                 // to 50% or higher. Even 300%+ is possible if accompanied with Safe Data Transfer.
-                if (!connection.enableSecuritySignature) {
+                if (!connection.enableSmbjSecuritySignature) {
                     configBuilder.withDialects(
                         SMB2Dialect.SMB_2_1,
                         SMB2Dialect.SMB_2_0_2
                     )
                 }
             }
-            configBuilder.withSigningEnabled(connection.enableSecuritySignature)
+            configBuilder.withSigningEnabled(connection.enableSmbjSecuritySignature)
 
             val config = configBuilder.build()
             val client = SMBClient(config)

--- a/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
+++ b/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjClient.kt
@@ -131,7 +131,6 @@ class SmbjClient(
                 }
             }
             configBuilder.withSigningEnabled(connection.enableSmbjSecuritySignature)
-            configBuilder.withBufferSize(BUFFER_SIZE)
 
             val config = configBuilder.build()
             val client = SMBClient(config)

--- a/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjProxyFileCallback.kt
+++ b/data/storage/smbj/src/main/java/com/wa2c/android/cifsdocumentsprovider/data/storage/smbj/SmbjProxyFileCallback.kt
@@ -2,33 +2,35 @@ package com.wa2c.android.cifsdocumentsprovider.data.storage.smbj
 
 import android.os.ProxyFileDescriptorCallback
 import android.system.ErrnoException
+import android.system.OsConstants
 import com.hierynomus.smbj.share.File
 import com.wa2c.android.cifsdocumentsprovider.common.utils.logD
+import com.wa2c.android.cifsdocumentsprovider.common.utils.logE
 import com.wa2c.android.cifsdocumentsprovider.common.values.AccessMode
 import com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils.BackgroundBufferReader
-import com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils.checkAccessMode
-import com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils.processFileIo
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
+import com.wa2c.android.cifsdocumentsprovider.data.storage.interfaces.utils.BackgroundBufferWriter
+import kotlinx.coroutines.*
 import kotlin.coroutines.CoroutineContext
 
 /**
- * Proxy File Callback for SMBJ (Buffering IO)
+ * Optimized Proxy File Callback for SMBJ.
+ * - Buffered reads for random access
+ * - Async buffered writes
  */
 class SmbjProxyFileCallback(
     private val file: File,
     private val accessMode: AccessMode,
-    private val onFileRelease: suspend () -> Unit,
+    private val onFileRelease: suspend () -> Unit
 ) : ProxyFileDescriptorCallback(), CoroutineScope {
 
     override val coroutineContext: CoroutineContext = Dispatchers.IO + Job()
 
-    /** File size */
+    /** File size (lazy to avoid SMB request until needed) */
     private val fileSize: Long by lazy {
-        processFileIo(coroutineContext) { file.fileInformation.standardInformation.endOfFile }
+        runBlocking(coroutineContext) { file.fileInformation.standardInformation.endOfFile }
     }
 
+    /** Buffered reader for low-latency random access */
     private val readerLazy = lazy {
         BackgroundBufferReader(fileSize) { start, array, off, len ->
             file.read(array, start, off, len)
@@ -37,43 +39,82 @@ class SmbjProxyFileCallback(
 
     private val reader: BackgroundBufferReader get() = readerLazy.value
 
-    @Throws(ErrnoException::class)
-    override fun onGetSize(): Long {
-        return fileSize
+    /** Buffered writer for async writes (only created if writable) */
+    private val writerLazy = lazy {
+        BackgroundBufferWriter() { start, array, off, len ->
+            file.write(array, start, off, len)
+        }
     }
 
+    private val writer: BackgroundBufferWriter?
+        get() = if (accessMode == AccessMode.W) writerLazy.value else null
+
+    /** ==================== ProxyFileDescriptorCallback ==================== */
+
+    @Throws(ErrnoException::class)
+    override fun onGetSize(): Long = fileSize
+
+    /**
+     * Optimized synchronous read
+     */
     @Throws(ErrnoException::class)
     override fun onRead(offset: Long, size: Int, data: ByteArray): Int {
-        return processFileIo(coroutineContext) {
-            reader.readBuffer(offset, size, data)
+        if (accessMode == AccessMode.W) {
+            // W mode can also read because SAF "rw" allows read
+        } else if (accessMode != AccessMode.R) {
+            throw ErrnoException("EBADF", OsConstants.EBADF)
+        }
+        return try {
+            runBlocking {
+                reader.readBuffer(offset, size, data)
+            }
+        } catch (e: Exception) {
+            logE(e)
+            throw ErrnoException("EIO", OsConstants.EIO)
         }
     }
 
+    /**
+     * Buffered async write (enqueue to writer)
+     */
     @Throws(ErrnoException::class)
     override fun onWrite(offset: Long, size: Int, data: ByteArray): Int {
-        return processFileIo(coroutineContext) {
-            checkAccessMode(accessMode)
-            file.writeAsync(data, offset, 0, size)
-            size
+        if (accessMode != AccessMode.W) throw ErrnoException("EBADF", OsConstants.EBADF)
+        return try {
+            writer?.writeBuffer(offset, size, data) ?: 0
+        } catch (e: Exception) {
+            logE(e)
+            throw ErrnoException("EIO", OsConstants.EIO)
         }
     }
-    
+
+    /**
+     * Called on fsync, ensure buffers are flushed
+     */
     @Throws(ErrnoException::class)
     override fun onFsync() {
-        // Nothing to do
+        try {
+            writer?.close() // flush any remaining buffer
+        } catch (e: Exception) {
+            logE(e)
+        }
     }
 
+    /**
+     * Called when FD is released
+     */
     @Throws(ErrnoException::class)
     override fun onRelease() {
         logD("onRelease: ${file.uncPath}")
-        processFileIo(coroutineContext) {
-            logD("release begin")
-            if (readerLazy.isInitialized()) {
-                reader.close()
+        runBlocking(coroutineContext) {
+            try {
+                if (readerLazy.isInitialized()) reader.close()
+                if (writerLazy.isInitialized()) writer?.close()
+                onFileRelease()
+            } catch (e: Exception) {
+                logE(e)
             }
-            onFileRelease()
-            logD("release end")
         }
+        logD("Release complete: ${file.uncPath}")
     }
-
 }

--- a/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/mapper/DomainMapper.kt
+++ b/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/mapper/DomainMapper.kt
@@ -127,7 +127,8 @@ internal object DomainMapper {
                     port = port,
                     enableDfs = enableDfs,
                     enableEncryption = enableEncryption,
-                    enableSecuritySignature = enableSecuritySignature,
+                    enableSmbjSecuritySignature = enableSmbjSecuritySignature,
+                    enableJcifsSecuritySignature = enableJcifsSecuritySignature,
                     folder = folder,
                     user = user,
                     password = password,
@@ -239,7 +240,8 @@ internal object DomainMapper {
                     domain = domain,
                     enableDfs = enableDfs,
                     enableEncryption = enableEncryption,
-                    enableSecuritySignature =  enableSecuritySignature,
+                    enableSmbjSecuritySignature = enableSmbjSecuritySignature,
+                    enableJcifsSecuritySignature = enableJcifsSecuritySignature,
                 )
             }
             StorageType.APACHE_FTP,

--- a/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/mapper/DomainMapper.kt
+++ b/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/mapper/DomainMapper.kt
@@ -127,6 +127,7 @@ internal object DomainMapper {
                     port = port,
                     enableDfs = enableDfs,
                     enableEncryption = enableEncryption,
+                    enableSecuritySignature = enableSecuritySignature,
                     folder = folder,
                     user = user,
                     password = password,
@@ -238,6 +239,7 @@ internal object DomainMapper {
                     domain = domain,
                     enableDfs = enableDfs,
                     enableEncryption = enableEncryption,
+                    enableSecuritySignature =  enableSecuritySignature,
                 )
             }
             StorageType.APACHE_FTP,

--- a/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/model/RemoteConnection.kt
+++ b/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/model/RemoteConnection.kt
@@ -26,6 +26,7 @@ data class RemoteConnection(
     val port: String? = null,
     val enableDfs: Boolean = false,
     val enableEncryption: Boolean = false,
+    val enableSecuritySignature: Boolean = true,
     val folder: String? = null,
     val user: String? = null,
     val password: String? = null,
@@ -74,6 +75,7 @@ data class RemoteConnection(
                 || this.port != other.port
                 || this.enableDfs != other.enableDfs
                 || this.enableEncryption != other.enableEncryption
+                || this.enableSecuritySignature != other.enableSecuritySignature
                 || this.folder != other.folder
                 || this.user != other.user
                 || this.password != other.password

--- a/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/model/RemoteConnection.kt
+++ b/domain/src/main/java/com/wa2c/android/cifsdocumentsprovider/domain/model/RemoteConnection.kt
@@ -26,7 +26,8 @@ data class RemoteConnection(
     val port: String? = null,
     val enableDfs: Boolean = false,
     val enableEncryption: Boolean = false,
-    val enableSecuritySignature: Boolean = true,
+    val enableSmbjSecuritySignature: Boolean = true,
+    val enableJcifsSecuritySignature: Boolean = false,
     val folder: String? = null,
     val user: String? = null,
     val password: String? = null,
@@ -75,7 +76,8 @@ data class RemoteConnection(
                 || this.port != other.port
                 || this.enableDfs != other.enableDfs
                 || this.enableEncryption != other.enableEncryption
-                || this.enableSecuritySignature != other.enableSecuritySignature
+                || this.enableSmbjSecuritySignature != other.enableSmbjSecuritySignature
+                || this.enableJcifsSecuritySignature != other.enableJcifsSecuritySignature
                 || this.folder != other.folder
                 || this.user != other.user
                 || this.password != other.password

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/edit/EditScreen.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/edit/EditScreen.kt
@@ -526,12 +526,23 @@ private fun EditScreenContainer(
                             ) {
                                 connectionState.value = connectionState.value.copy(enableEncryption = it)
                             }
+                            // for SMBJ default value for signing is true
                             InputCheck(
                                 title = stringResource(id = R.string.edit_enable_security_signature),
-                                value = connectionState.value.enableSecuritySignature,
+                                value = connectionState.value.enableSmbjSecuritySignature,
                                 focusManager = focusManager,
                             ) {
-                                connectionState.value = connectionState.value.copy(enableSecuritySignature = it)
+                                connectionState.value = connectionState.value.copy(enableSmbjSecuritySignature = it)
+                            }
+                        } else if (connectionState.value.storage == StorageType.JCIFS ||
+                            connectionState.value.storage == StorageType.JCIFS_LEGACY) {
+                            // jCIFS/jCIFS-NG default value for signing is false
+                            InputCheck(
+                                title = stringResource(id = R.string.edit_enable_security_signature),
+                                value = connectionState.value.enableJcifsSecuritySignature,
+                                focusManager = focusManager,
+                            ) {
+                                connectionState.value = connectionState.value.copy(enableJcifsSecuritySignature = it)
                             }
                         }
                     }

--- a/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/edit/EditScreen.kt
+++ b/presentation/src/main/java/com/wa2c/android/cifsdocumentsprovider/presentation/ui/edit/EditScreen.kt
@@ -526,6 +526,13 @@ private fun EditScreenContainer(
                             ) {
                                 connectionState.value = connectionState.value.copy(enableEncryption = it)
                             }
+                            InputCheck(
+                                title = stringResource(id = R.string.edit_enable_security_signature),
+                                value = connectionState.value.enableSecuritySignature,
+                                focusManager = focusManager,
+                            ) {
+                                connectionState.value = connectionState.value.copy(enableSecuritySignature = it)
+                            }
                         }
                     }
 

--- a/presentation/src/main/res/values-ar/strings.xml
+++ b/presentation/src/main/res/values-ar/strings.xml
@@ -8,10 +8,10 @@
     <string name="app_summary">الوصول إلى التخزين عبر الإنترنت</string>
     <string name="general_accept">حسنا</string>
     <string name="general_close">إغلاق</string>
-    <string name="general_warning">انتباه</string>
+    <string name="general_warning">إنتبه</string>
     <string name="general_yes">نعم</string>
     <string name="general_no">لا</string>
-    <string name="general_delete">يمسح</string>
+    <string name="general_delete">إمسح</string>
     <string name="general_back">خلف</string>
     <string name="general_copy_clipboard_message">نسخ إلى الحافظة.</string>
     
@@ -19,8 +19,8 @@
     <string name="home_open_file">فتح</string>
     <string name="home_open_settings">الإعدادات</string>
     <string name="home_open_file_ng_message">أضف أي إتصال</string>
-    <string name="home_add_connection_input">مدخل</string>
-    <string name="home_add_connection_search">يبحث</string>
+    <string name="home_add_connection_input">أدخل</string>
+    <string name="home_add_connection_search">إبحث</string>
     
     <!-- Edit Screen -->
     <string name="edit_title">إتصال</string>
@@ -33,17 +33,18 @@
     <string name="edit_domain_title">النطاق</string>
     <string name="edit_domain_hint">الإدخال حسب الحاجة</string>
     <string name="edit_host_title">المضيف</string>
-    <string name="edit_host_hint">عنوان ال ( آي بي ) للمضيف / الخادم</string>
+    <string name="edit_host_hint">عنوان ال IP للمضيف / الخادم</string>
     <string name="edit_host_select_a11y">تصفح</string>
     <string name="edit_port_title">بوابة</string>
     <string name="edit_port_hint">أهمل إن كان خاليا</string>
-    <string name="edit_enable_dfs_label">فعّل - دي إف أس - ( نظام الملفات الموزعة )</string>
-    <string name="edit_enable_encryption_label">تمكين التشفير</string>
+    <string name="edit_enable_dfs_label">تفعيل DFS ( نظام الملفات الموزعة )</string>
+    <string name="edit_enable_encryption_label">تفعيل التشفير</string>
+    <string name="edit_enable_security_signature">تفعيل توقيع الأمان</string>
     <string name="edit_directory_search_a11y">تصفح</string>
     <string name="edit_user_title">المستخدم</string>
-    <string name="edit_user_hint">باطل إذا كان مجهول</string>
+    <string name="edit_user_hint">غير صالح إذا كان مجهول</string>
     <string name="edit_password_title">كلمة المرور</string>
-    <string name="edit_password_hint">باطل إذا كان مجهول</string>
+    <string name="edit_password_hint">غير صالح إذا كان مجهول</string>
     <string name="edit_anonymous_label">مجهول</string>
     <string name="edit_key_title">مفتاح سري</string>
     <string name="edit_key_hint">مفتاح سري</string>
@@ -65,12 +66,12 @@
     <string name="edit_option_section_title">خيارات</string>
     <string name="edit_option_safe_transfer_label">نقل بيانات آمن</string>
     <string name="edit_option_read_only_label">يقرأ فقط</string>
-    <string name="edit_option_extension_label">أضف وصلة عند الحفظ</string>
+    <string name="edit_option_extension_label">أضف وصلة إلى الملف عند الحفظ</string>
     <string name="edit_option_thumbnail_label">ظفري</string>
     <string name="edit_option_thumbnail_image">صورة</string>
     <string name="edit_option_thumbnail_audio">صوتي</string>
     <string name="edit_option_thumbnail_video">فيديو</string>
-    <string name="edit_option_thumbnail_disabled">عاجز</string>
+    <string name="edit_option_thumbnail_disabled">غير مفعل</string>
     <string name="edit_info_section_title">معلومات</string>
     <string name="edit_storage_uri_title">عنوان التخزين</string>
     <string name="edit_provider_uri_title">عنوان التشارك</string>
@@ -95,15 +96,15 @@
     <string name="host_set_manually">تحديد يدويا</string>
     <string name="host_select_confirmation_message">أدخل البيانات المختارة لتعديل عليها في الأنموذج</string>
     <string name="host_select_host_name">إسم المضيف</string>
-    <string name="host_select_ip_address">عنوان ال ( آي بي )</string>
+    <string name="host_select_ip_address">عنوان ال IP</string>
     <string name="host_sort_button">فرز</string>
     <string name="host_reload_button">إعادة تحميل</string>
     <string name="host_sort_type_detection_ascend">تحرى (تصاعديا)</string>
     <string name="host_sort_type_detection_descend">تحرى (تنازليا)</string>
     <string name="host_sort_type_host_name_ascend">إسم المضيف (تصاعديا)</string>
     <string name="host_sort_type_host_name_descend">إسم المضيف (تنازليا)</string>
-    <string name="host_sort_type_ip_address_ascend">عنوان ال ( آي بي ) (تصاعديا)</string>
-    <string name="host_sort_type_ip_address_descend">عنوان ال ( آي بي ) (تنازليا)</string>
+    <string name="host_sort_type_ip_address_ascend">عنوان ال IP (تصاعديا)</string>
+    <string name="host_sort_type_ip_address_descend">عنوان ال IP (تنازليا)</string>
     
     <!-- Folder Screen -->
     <string name="folder_title">مجلد</string>
@@ -123,7 +124,7 @@
     <string name="settings_transfer_export">تصدير إعدادات الاتصال</string>
     <string name="settings_transfer_export_dialog_password">كلمة المرور (1-32 حرفًا)</string>
     <string name="settings_transfer_export_dialog_check">هدف التصدير</string>
-    <string name="settings_transfer_export_dialog_button">يصدّر</string>
+    <string name="settings_transfer_export_dialog_button">صدّر</string>
     <string name="settings_transfer_export_message">تم تصدير %1$d من البيانات.</string>
     <string name="settings_transfer_export_error">فشل تصدير البيانات.</string>
     <string name="settings_transfer_import">استيراد إعدادات الاتصال</string>
@@ -131,11 +132,11 @@
     <string name="settings_transfer_import_dialog_option_replace">استبدال كافة البيانات</string>
     <string name="settings_transfer_import_dialog_option_duplicate">تغيير المعرف (تغيير URI المشترك)</string>
     <string name="settings_transfer_import_dialog_option_overwrite">الكتابة فوق</string>
-    <string name="settings_transfer_import_dialog_option_ignore">يتجاهل</string>
+    <string name="settings_transfer_import_dialog_option_ignore">تجاهل</string>
     <string name="settings_transfer_import_dialog_option_append">تغيير المعرف (تغييرات عنوان URL)</string>
-    <string name="settings_transfer_import_dialog_button">يستورد</string>
-    <string name="settings_transfer_import_message">تم استيراد %1$d من البيانات.</string>
-    <string name="settings_transfer_import_error">فشل استيراد البيانات.</string>
+    <string name="settings_transfer_import_dialog_button">إستورد</string>
+    <string name="settings_transfer_import_message">تم إستيراد %1$d من البيانات.</string>
+    <string name="settings_transfer_import_error">فشل إستيراد البيانات.</string>
     <string name="settings_section_info">معلومات</string>
     <string name="settings_info_known_hosts">المضيفين الموثوقين عبر SSH</string>
     <string name="settings_info_known_hosts_host">المضيف</string>
@@ -158,7 +159,7 @@
     <string name="send_state_failure">فشل</string>
     <string name="send_state_cancel">ملغى</string>
     <string name="send_exit_confirmation_message">إلغاء كل عمليات النقل و الخروج من التطبيق</string>
-    <string name="send_overwrite_confirmation_message">(استبدال الملفات) Overwrite %1$d files.</string>
+    <string name="send_overwrite_confirmation_message">(إستبدال الملفات) Overwrite %1$d files.</string>
     
     <!-- DocumentsProvider -->
     <string name="provider_error_message">حصل خطأ ما</string>
@@ -167,7 +168,7 @@
     <string name="notification_channel_name_provider">فتح ملف</string>
     <string name="notification_title_provider">عملية فتح الملف</string>
     <string name="notification_channel_name_send">نقل البيانات</string>
-    <string name="notification_title_send_completed">تمام</string>
+    <string name="notification_title_send_completed">مكتمل</string>
     
     <!-- Theme Enum -->
     <string name="enum_theme_default">الوضع الطبيعي</string>

--- a/presentation/src/main/res/values-ja/strings.xml
+++ b/presentation/src/main/res/values-ja/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint">未入力の場合は標準ポート</string>
     <string name="edit_enable_dfs_label">DFS(Distributed File System)利用</string>
     <string name="edit_enable_encryption_label">暗号化を有効にする</string>
+    <string name="edit_enable_security_signature">セキュリティ署名を有効にする</string>
     <string name="edit_directory_search_a11y">閲覧</string>
     <string name="edit_user_title">ユーザ名</string>
     <string name="edit_user_hint">匿名の場合は無効</string>

--- a/presentation/src/main/res/values-my/strings.xml
+++ b/presentation/src/main/res/values-my/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint"> ပုံသေ အလွတ်</string>
     <string name="edit_enable_dfs_label">DFS (ဖြန့်ဝေထားသောဖိုင်စနစ်) ကိုဖွင့်ပါ</string>
     <string name="edit_enable_encryption_label">ကုဒ်ဝှက်ခြင်းကို ဖွင့်ပါ။</string>
+    <string name="edit_enable_security_signature">လုံခြုံရေးလက်မှတ်ဖွင့်ပါ</string>
     <string name="edit_directory_search_a11y">ဘရောက်ဆာ</string>
     <string name="edit_user_title">အသုံးပြုသူ</string>
     <string name="edit_user_hint">အမည်မသိလျှင် မမှန်ကန်ပါ</string>

--- a/presentation/src/main/res/values-ru/strings.xml
+++ b/presentation/src/main/res/values-ru/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint">Если пусто то по умолчанию</string>
     <string name="edit_enable_dfs_label">Включить DFS (Distributed File System)</string>
     <string name="edit_enable_encryption_label">Включить шифрование</string>
+    <string name="edit_enable_security_signature">Включить цифровую подпись</string>
     <string name="edit_directory_search_a11y">Просмотр</string>
     <string name="edit_user_title">Пользователь</string>
     <string name="edit_user_hint">Неправильно если анонимно</string>

--- a/presentation/src/main/res/values-sk/strings.xml
+++ b/presentation/src/main/res/values-sk/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint">Predvolený, ak nevyplníte</string>
     <string name="edit_enable_dfs_label">Povoliť DFS (distribuovaný systém súborov)</string>
     <string name="edit_enable_encryption_label">Povoliť šifrovanie</string>
+    <string name="edit_enable_security_signature">Zapnúť bezpečnostný podpis</string>
     <string name="edit_directory_search_a11y">Prehľadávať</string>
     <string name="edit_user_title">Meno používateľa</string>
     <string name="edit_user_hint">Neplatí pre anonymné prihlásenie</string>

--- a/presentation/src/main/res/values-zh-rCN/strings.xml
+++ b/presentation/src/main/res/values-zh-rCN/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint">如果留空则为默认值</string>
     <string name="edit_enable_dfs_label">启用DFS（分布式文件系统）</string>
     <string name="edit_enable_encryption_label">启用加密</string>
+    <string name="edit_enable_security_signature">启用安全签名</string>
     <string name="edit_directory_search_a11y">浏览</string>
     <string name="edit_user_title">用户名</string>
     <string name="edit_user_hint">匿名访问时无效</string>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="edit_port_hint">Default if empty</string>
     <string name="edit_enable_dfs_label">Enable DFS (Distributed File System)</string>
     <string name="edit_enable_encryption_label">Enable Encryption</string>
+    <string name="edit_enable_security_signature">Enable Security Signature</string>
     <string name="edit_directory_search_a11y">Browse</string>
     <string name="edit_user_title">User</string>
     <string name="edit_user_hint">Invalid if anonymous</string>
@@ -121,13 +122,13 @@
     <string name="settings_set_use_as_local">Use as local storage\n(Device reboot required)</string>
     <string name="settings_section_transfer">Import / Export</string>
     <string name="settings_transfer_export">Export connection settings</string>
-    <string name="settings_transfer_export_dialog_password">Password (1-32 characters)</string>
+    <string name="settings_transfer_export_dialog_password">Password (1–32 characters)</string>
     <string name="settings_transfer_export_dialog_check">Export target</string>
     <string name="settings_transfer_export_dialog_button">Export</string>
     <string name="settings_transfer_export_message">%1$d data exported.</string>
     <string name="settings_transfer_export_error">Failed to export data.</string>
     <string name="settings_transfer_import">Import connection settings</string>
-    <string name="settings_transfer_import_dialog_password">Password (1-32 characters)</string>
+    <string name="settings_transfer_import_dialog_password">Password (1–32 characters)</string>
     <string name="settings_transfer_import_dialog_option_replace">Replace all data</string>
     <string name="settings_transfer_import_dialog_option_duplicate">ID duplicate data</string>
     <string name="settings_transfer_import_dialog_option_overwrite">Overwrite</string>


### PR DESCRIPTION
First, I apologize for the lengthy explanation here, I just want to be thorough 👍🏻

🔶 Rewrote **BackgroundBufferReader** and **BackgroundBufferWriter** for faster, lag-free, non-blocking
main thread of the caller app (any app uses the document provider and waiting for the data to be fetched).

I tested this extensively, copying huge files and checking their CRC values, no corruption. Also, gaming using
PPSSPP emulator loading disc images from SMB share is now lag free, no micro stutters anymore as if the disc
images were loaded from internal storage. This ultimately depends on your SMB speed on your local network.

This should result in faster responses for media apps too, I tested time seeking for video files located on SMB
server and I had no issues at all and instant (or near instant) results.

NOTE: current implementation is still not perfect, as is the original implementation before this modification.

So, if you try to COPY data from SMB_J_CONNECTION_A to JCIFS_NG__CONNECTION_B from `FILES` app you
will get corrupted data, since the cache is shared for all connections. A proper way to fix this is to isolate the cache
between connections.

🔶 Auto-Switch between **Native I/O** and **Buffered I/O** depending on number of files opened.

Uses `normal proxy callback` Buffered I/O mode for :
🔸Single-file access (such as, copying, moving, reading all or big portion of a big file for example).
🔸Multiple connections to the same file (if file was opened multiple time from different apps at the same time)

Uses `safe proxy callback` Native I/O mode for :
  🔸Multiple files opened in parallel at the same time. (such as quickly reading files partially in a directory).
  🔸When explicitly enabled in settings, Safe Data Transfer is always applied and auto-switching will not be applied.
 
With this new implementation for SMBJ and jCIFS-NG, when leaving the option
for `Safe Data Transfer` unchecked, smart Auto-Switch behavior takes effect. This brings the
benefits of both worlds, fast single file **Sequential** operations and fast multiple files **Random Access** performance.

### My tests show
  🔸 200%-300%+ performance improvement in Buffered mode compared to Native.
When opening big file and do operations like copying, calculating CRC and basically examine 
every single byte of the file sequentially. 

For example, reading sequentially full 3GB file takes
a little over a minute in buffered mode, while in native mode it takes over 4 minutes.

  🔸 200%-400%+ performance improvement in Native mode compared to Buffer.
When opening multiple files at the same time to read partial data from files and not reading the
whole files, such as meta data, ID3 tag for music files, opening files to read header to determine type...etc.

For example, opening 53 big files (about 300GB total) to read some data from them (at random) in parallel
about 6 files at a time takes about 6-7 seconds in Native mode while it takes in Buffered mode about 36 seconds.

With this new approach, you will have the best of both **Buffered and Native** automatically depending on what
is being opened.

🔶 Add option to enable security signature for both SMBJ and jCIFS-NG.
🗒️Note that the default preferred behavior for JCIFS-NG for signing is **Disabled**,
while the default value for signing for SMBJ is **Enabled**.

If the server requires signing and signing is disabled, then connection will fail.
But giving an option to the user to trade Security vs Performance is a good thing.
Especially if the performance gain is more than double according to my tests for SMBJ,
and I noticed for jCIFS-NG that signing does not affect performance negatively as much
as SMBj. It is however slower than when it is disabled which is again, the default for jCIFS-NG.

See: https://www.ibm.com/docs/en/storediq/7.6.0?topic=volumes-configuring-smb-properties

🔶 Add translations for all languages for this new option.
🔶 Tweaked some Arabic translations.

<img width="467" height="355" alt="image" src="https://github.com/user-attachments/assets/b45b671f-ecc9-40ab-b04c-ddd8c00d5b1e" />

The new option to Enable Security Signature is enabled by default.
Since this is the default behavior.

I tested Exporting and Importing settings and everything is working
fine for new connections made after this patch. 

But existing exported settings (before this patch) do not know about this
new setting.  Thus, when imported, CIFS Document Provider sets its value
as false (disabled), which is incorrect and something I couldn't be able to fix. 
If a user enabled encryption and imported the settings, the signing option
would be disabled and it shouldn't, and the connection will fail. The user
needs to check and enable signing if encryption is enabled.

I believe the import function should be changed to set new setting(s) values 
that were not there when they were exported before, to their default values 
instead of just make them empty or false.

**Note:** 
Signing is required for SMB dialects 3.x, at least in SMBJ. Connection testing
will throw an error that signing can not be disabled for 3.x. 

So, we opt for SMB dialect 2.x *ONLY* if both encryption and signing
are both disabled. This resulting in a big speed boost ranging from 25%
to 50% or higher. Even 300%+ is possible if accompanied with Safe Data Transfer.

## Rational:
Windows 11 24H2 Pro, Enterprise, Education and Server 2025
started enforcing signing SMB packets. But this is NOT required for
Home edition of Windows 11 24H2. See the link below for more
information:

https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-signing

From the link, this could also allow unauthenticated guest accounts connect to
shares when disabling signing.

While enabling this option adds security and prevents Man-in-the-Middle
(MITM) attacks. It incurs along with enabling Encryption severe performance
loss.

Some claim (using Windows shares) with encryption and signing disabled
they have 825MB/s for 10Gb ethernet. While both enabled 225MB/s. And I would
believe it according to my tests.

And arguably, if there is a MITM attack in my local network, then I
would have a bigger problem at hand of why the attacker is inside my local network
in the first place. Since SMB/CIFS is for local network only.

## Tests

**### Note: These tests were done before Auto-Switching between Native and Buffered modes.
After the new patch with encryption and signing disabled, the performance is almost the same 
as in Windows PC accessing a NAS.**

Small tests I did showed when scanning directories
and opening huge compressed files to read some few
data from each file (meta data, should be few kilobytes):

Tests were done in Nvidia Shield 2019 Pro, I chose it since
it has native SMB mounting feature built in with its firmware.
And I installed CIFS Document Provider there to compare.

The seconds are rounded up to the nearest second.
I used a debug build of CIFS Document Provider, but
should reflect same picture for the release build.

- Using Nvidia Shield's native SMB: 4 seconds
## Using CIFS Document Provider in Nvidia Shield :

**--- Safe Data Transfer Disabled (Buffered I/O)**
💠 Encryption and Signing both Enabled: 86 seconds.
I didn't bother continuing tests with Safe Data Transfer disabled :)

**--- Safe Data Transfer Enabled (Native I/O)**
💠 Encryption and Signing both Enabled: 15 seconds.
💠 Encryption disabled and Signing Enabled: 11 seconds.
💠 Encryption and Signing both Disabled: 6 seconds

Please see the original issues at SMBJ's repo:

https://github.com/hierynomus/smbj/issues/817
https://github.com/hierynomus/smbj/issues/862

It seems it is an issue with SMBJ and to fix this issue, it seems they faked signing the packets, as in here

https://github.com/JozefDropco/smbj/commit/9df23a1eedd04ae7f3362efd15e29f2f3dfce0aa